### PR TITLE
Update textarea_widget.html.php

### DIFF
--- a/src/ShopwareSymfonyForms/FormFactory/Resources/views/Form/textarea_widget.html.php
+++ b/src/ShopwareSymfonyForms/FormFactory/Resources/views/Form/textarea_widget.html.php
@@ -1,7 +1,4 @@
 <?php
-$class = isset($class) ? $class : '';
-if (!isset($type) || 'file' != $type) {
-    $attr['class'] = trim($class . ' ' . $view['form']->block($form, 'form_widget_class') . ' ' . $view['form']->block($form, 'form_error'));
-}
+    $attr['class'] = trim($attr['class'] . ' ' . $view['form']->block($form, 'form_widget_class') . ' ' . $view['form']->block($form, 'form_error'));
 ?>
 <textarea <?php echo $view['form']->block($form, 'widget_attributes', ['attr' => $attr]) ?>><?php echo $view->escape($value) ?></textarea>


### PR DESCRIPTION
seems like a copy-paste-error from an input widget,
no type necessary, $attr['class'] should not get lost since it comes from the formBuilder